### PR TITLE
New parameter for synch_branch, to allow a specific default branch name.

### DIFF
--- a/R/publish_wiki.R
+++ b/R/publish_wiki.R
@@ -138,7 +138,7 @@ publish_wiki <- function(rmarkdown, path_wiki_repo, automatic_update = FALSE,
         paste("git add", md), "\n",
         paste("git add", files_folder), "\n",
         paste0("git commit -m 'Update ", base_name, "'"), "\n",
-        "git push")
+        "git push \n")
 
     } else {
 
@@ -148,7 +148,7 @@ publish_wiki <- function(rmarkdown, path_wiki_repo, automatic_update = FALSE,
         paste("git pull"), "\n",
         paste("git add", md), "\n",
         paste0("git commit -m 'Update ", base_name, "'"), "\n",
-        "git push")
+        "git push \n")
 
     }
 

--- a/R/sync_branch.R
+++ b/R/sync_branch.R
@@ -5,15 +5,15 @@
 #'
 #' @return
 #' @export
-synch_branch <- function() {
+synch_branch <- function(default_branch_name = "master") {
 
   remotes <- gert::git_remote_list(repo = ".")
 
   if (("upstream" %in% remotes$name) == TRUE) {
 
     gert::git_fetch(remote = "upstream")
-    gert::git_branch_checkout(branch = "master")
-    gert::git_rebase_commit("upstream/master")
+    gert::git_branch_checkout(branch = default_branch_name)
+    gert::git_rebase_commit(paste0("upstream/", default_branch_name))
     gert::git_push()
 
   } else {


### PR DESCRIPTION
New default in git is "main". This parameter allows it to be used to synch_branch.

Also, in publish_wiki a new line is added after the "git push" call, so the R warnings are not displayed in the same line. 